### PR TITLE
Fix a S3ServiceException when using an input prefix

### DIFF
--- a/src/org/commoncrawl/hadoop/io/JetS3tARCSource.java
+++ b/src/org/commoncrawl/hadoop/io/JetS3tARCSource.java
@@ -238,8 +238,11 @@ public class JetS3tARCSource extends ARCSplitCalculator implements ARCSource,
       Map<String, ARCResource> resources = new HashMap<String, ARCResource>();
       for (String prefix : getInputPrefixes(job)) {
         for (S3Object object : service.listObjects(bucket, prefix, null)) {
-          String key = object.getKey();
-          resources.put(key, new ARCResource(key, object.getContentLength()));
+          long length = object.getContentLength();
+          if (length > 0) {
+            String key = object.getKey();
+            resources.put(key, new ARCResource(key, length));
+          }
         }
       }
       return resources.values();


### PR DESCRIPTION
Listing directories as resources trigger errors such as:
org.jets3t.service.S3ServiceException: S3 GET failed for '/data%2F' XML Error Message: <?xml version="1.0" encoding="UTF-8"?><Error><Code>InvalidRange</Code><Message>The requested range is not satisfiable</Message><ActualObjectSize>0</ActualObjectSize><RequestId>F063C5C315CC967B</RequestId><HostId>HiShCYLg5oo+hdZceTVRkhhqebTZL5kl1m2gqf+0a0Mme+CSS0d2e9RERPMmcnPY</HostId><RangeRequested>bytes=0-</RangeRequested></Error>
  at org.jets3t.service.impl.rest.httpclient.RestS3Service.performRequest(RestS3Service.java:416)
  at org.jets3t.service.impl.rest.httpclient.RestS3Service.performRestGet(RestS3Service.java:752)
  at org.jets3t.service.impl.rest.httpclient.RestS3Service.getObjectImpl(RestS3Service.java:1601)
  at org.jets3t.service.impl.rest.httpclient.RestS3Service.getObjectImpl(RestS3Service.java:1544)
  at org.jets3t.service.S3Service.getObject(S3Service.java:2072)
  at org.commoncrawl.hadoop.io.JetS3tARCSource.getStream(JetS3tARCSource.java:261)
